### PR TITLE
Set up the FDB module and add base package

### DIFF
--- a/extensions/datastores/foundationdb/pom.xml
+++ b/extensions/datastores/foundationdb/pom.xml
@@ -21,6 +21,11 @@
             <artifactId>geowave-core-cli</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.foundationdb</groupId>
+            <artifactId>fdb-java</artifactId>
+            <version>6.1.9</version>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/extensions/datastores/foundationdb/pom.xml
+++ b/extensions/datastores/foundationdb/pom.xml
@@ -24,7 +24,6 @@
         <dependency>
             <groupId>org.foundationdb</groupId>
             <artifactId>fdb-java</artifactId>
-            <version>6.1.9</version>
         </dependency>
     </dependencies>
     <profiles>

--- a/extensions/datastores/foundationdb/pom.xml
+++ b/extensions/datastores/foundationdb/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>geowave-extension-parent</artifactId>
+        <groupId>org.locationtech.geowave</groupId>
+        <relativePath>../../</relativePath>
+        <version>1.1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>geowave-datastore-foundationdb</artifactId>
+    <name>GeoWave FoundationDB</name>
+    <description>Geowave Data Store on FoundationDB</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.locationtech.geowave</groupId>
+            <artifactId>geowave-core-mapreduce</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geowave</groupId>
+            <artifactId>geowave-core-cli</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <profile>
+            <id>build-installer-plugin</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/extensions/datastores/foundationdb/src/main/java/org/locationtech/geowave/datastore/foundationdb/FoundationDBDataStore.java
+++ b/extensions/datastores/foundationdb/src/main/java/org/locationtech/geowave/datastore/foundationdb/FoundationDBDataStore.java
@@ -1,0 +1,28 @@
+package org.locationtech.geowave.datastore.foundationdb;
+
+import org.locationtech.geowave.core.store.DataStoreOptions;
+import org.locationtech.geowave.core.store.metadata.*;
+import org.locationtech.geowave.mapreduce.BaseMapReduceDataStore;
+import org.locationtech.geowave.mapreduce.MapReduceDataStoreOperations;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+public class FoundationDBDataStore extends BaseMapReduceDataStore implements Closeable {
+    // TODO: implement FoundationDBOperations
+    public FoundationDBDataStore(final MapReduceDataStoreOperations operations, final DataStoreOptions options) {
+        super(
+                new IndexStoreImpl(operations, options),
+                new AdapterStoreImpl(operations, options),
+                new DataStatisticsStoreImpl(operations, options),
+                new AdapterIndexMappingStoreImpl(operations, options),
+                operations,
+                options,
+                new InternalAdapterStoreImpl(operations));
+    }
+
+    @Override
+    public void close() throws IOException {
+        // TODO: implement FoundationDBOperations
+    }
+}

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -19,6 +19,7 @@
 		<module>datastores/bigtable</module>
 		<module>datastores/cassandra</module>
 		<module>datastores/dynamodb</module>
+		<module>datastores/foundationdb</module>
 		<module>datastores/redis</module>
 		<module>datastores/rocksdb</module>
 		<module>datastores/kudu</module>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
 		<cassandra.version>3.11.3</cassandra.version>
 		<redisson.version>3.8.2</redisson.version>
 		<rocksdb.version>5.15.10</rocksdb.version>
+		<foundationdb.version>6.1.9</foundationdb.version>
 		<cassandraclient.version>3.5.1</cassandraclient.version>
 		<kuduclient.version>1.8.0</kuduclient.version>
 		<grpc.version>1.13.1</grpc.version>
@@ -307,6 +308,11 @@
 				<groupId>org.rocksdb</groupId>
 				<artifactId>rocksdbjni</artifactId>
 				<version>${rocksdb.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.foundationdb</groupId>
+				<artifactId>fdb-java</artifactId>
+				<version>${foundationdb.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.accumulo</groupId>


### PR DESCRIPTION
Set up the Maven module for the foundationdb extension, and add the base `org.locationtech.geowave.datastore.foundationdb` package with a skeleton for the `FoundationDBDataStore` class.